### PR TITLE
Added TravisCI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,26 @@
+# general configuration
+sudo: required
 language: java
-sudo: false
+services:
+  - docker
 jdk:
-    - oraclejdk8
-script: mvn test
+  - oraclejdk8
+
+# install docker compose
+env:
+  COMPOSE_VERSION: 1.11.2
+before_install:
+  - curl -L https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+# build plugin and provision testing services and environment
+install: mvn install
+before_script:
+  - docker-compose up -d
+  - chmod +x run_test.sh
+
+# run unit tests and integration tests
+script:
+  - mvn test
+  - ./run_test.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+sonarqube:
+  image: sonarqube:5.6.3
+  volumes:
+    - ./target:/opt/sonarqube/extensions/plugins
+  ports:
+    - 9000:9000
+    - 9092:9092
+
+foreman:
+  image: shakedl/foreman-analysis:latest
+  links:
+    - sonarqube

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# run sonar scanner aginst the provisioned sonarqube server
+docker-compose run foreman /sonar-runner/sonar-scanner-2.6-SNAPSHOT/bin/sonar-scanner -X -e\
+	-Dsonar.host.url=http://sonarqube:9000\
+	-Dsonar.projectKey=some-test_ruby_plugin\
+	"-Dsonar.projectName=Test Ruby Plugin"\
+	-Dsonar.projectVersion=1.0\
+	-Dsonar.sources=/usr/src/app\
+	-Dsonar.projectBaseDir=/usr/src/app\
+	-Dsonar.python.coverage.reportPath=coverage.xml\
+	-Dsonar.language=ruby\
+	"-Dsonar.inclusions=**/*.rb"\
+	"-Dsonar.exclusions=test/**/*.rb,db/**/*.rb"\
+	-Dsonar.ws.timeout=180\


### PR DESCRIPTION
Added TravisCI support for:
* integration tests using TravisCI `docker-compose` support, provisioning a Sonar server and a testing environment
* unit testing using the `mvn test` command